### PR TITLE
Build: add linux/arm64 to docker build workflow (#648)

### DIFF
--- a/.github/workflows/release_to_docker.yml
+++ b/.github/workflows/release_to_docker.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           context: ./
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
- Add linux/arm64 to the docker push workflow so we can use the image on macs
- https://docs.docker.com/build/ci/github-actions/multi-platform/